### PR TITLE
Corrects defaults for redhat 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,13 @@ The standard cron time schedule. Default: once a week based on fqdn_rand
 
 Prune out bind mounts or not. Default: yes
 Refer to the updatedb.conf man page for more detail.
+On redhat 5 systems defaults to none.
 
 ####`prunenames`
 
 Prune out directories matching this pattern. Default: .git .hg .svn
 Refer to the updatedb.conf man page for more detail.
+On redhat 5 systems defaults to none.
 
 ####`extra_prunenames`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class mlocate (
   validate_string($cron_schedule)
 
   if $prune_bind_mounts {
-    validate_re($prune_bind_mounts, [ '^yes', '^no' ], "Error: \$prune_bund_mounts must be either 'yes', or 'no'")
+    validate_re($prune_bind_mounts, [ '^yes', '^no' ], "Error: \$prune_bind_mounts must be either 'yes', or 'no'")
   }
   validate_array($prunefs)
   validate_array($extra_prunefs)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,10 +96,14 @@ class mlocate (
   validate_re($cron_ensure, ['^present', '^absent'], "Error: \$cron_ensure must be either 'present' or 'absent'")
   validate_string($cron_schedule)
 
-  validate_re($prune_bind_mounts, [ '^yes', '^no' ], "Error: \$prune_bund_mounts must be either 'yes', or 'no'")
+  if $prune_bind_mounts {
+    validate_re($prune_bind_mounts, [ '^yes', '^no' ], "Error: \$prune_bund_mounts must be either 'yes', or 'no'")
+  }
   validate_array($prunefs)
   validate_array($extra_prunefs)
-  validate_array($prunenames)
+  if $prunenames {
+    validate_array($prunenames)
+  }
   validate_array($extra_prunenames)
   validate_array($prunepaths)
   validate_array($extra_prunepaths)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,8 +6,13 @@ class mlocate::params {
   $update_on_install  = true
   $conf_file          = '/etc/updatedb.conf'
   $cron_ensure        = 'present'
-  $prune_bind_mounts  = 'yes'
-  $prunenames         = [ '.git', '.hg', '.svn' ]
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == 5 {
+    $prune_bind_mounts  = undef
+    $prunenames = undef
+  } else {
+    $prunenames         = [ '.git', '.hg', '.svn' ]
+    $prune_bind_mounts  = 'yes'
+  }
 
   $prunefs = [
     '9p', 'afs', 'anon_inodefs', 'auto', 'autofs', 'bdev', 'binfmt_misc',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,5 +6,10 @@ describe 'mlocate' do
     it { should contain_class('mlocate') }
     it { should contain_class('mlocate::install') }
     it { should contain_class('mlocate::cron') }
+    it { should contain_file('updatedb.conf').with_path('/etc/updatedb.conf') }
+    it { should contain_file('updatedb.conf').with_content(/^PRUNE_BIND_MOUNTS = "yes"$/) }
+    it { should contain_file('updatedb.conf').with_content(/^PRUNENAMES = ".git .hg .svn"$/) }
+    it { should contain_file('updatedb.conf').with_content(/^PRUNEPATHS = \"\/afs .*$/) }
+    it { should contain_file('updatedb.conf').with_content(/^PRUNEFS = \"9p afs .*$/) }
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,5 +11,14 @@ describe 'mlocate' do
     it { should contain_file('updatedb.conf').with_content(/^PRUNENAMES = ".git .hg .svn"$/) }
     it { should contain_file('updatedb.conf').with_content(/^PRUNEPATHS = \"\/afs .*$/) }
     it { should contain_file('updatedb.conf').with_content(/^PRUNEFS = \"9p afs .*$/) }
+
+    context 'with facts osfamily, operatingsystemmajrelease set to redhat , 5' do
+        let(:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => 5} }
+        it { should contain_file('updatedb.conf').with_path('/etc/updatedb.conf') }
+        it { should_not contain_file('updatedb.conf').with_content(/^PRUNE_BIND_MOUNTS.*$/) }
+        it { should_not contain_file('updatedb.conf').with_content(/^PRUNENAMES.*$/) }
+        it { should contain_file('updatedb.conf').with_content(/^PRUNEPATHS = \"\/afs .*$/) }
+        it { should contain_file('updatedb.conf').with_content(/^PRUNEFS = \"9p afs .*$/) }
+    end
   end
 end

--- a/templates/updatedb.conf.erb
+++ b/templates/updatedb.conf.erb
@@ -1,6 +1,10 @@
 # This file is managed by puppet.
 #
+<% if @prune_bind_mounts -%>
 PRUNE_BIND_MOUNTS = "<%= @prune_bind_mounts %>"
+<% end -%>
 PRUNEFS = "<%= ((@prunefs << @extra_prunefs).flatten!).join(' ') %>"
+<% if @prunenames -%>
 PRUNENAMES = "<%= ((@prunenames << @extra_prunenames).flatten!).join(' ') %>"
+<% end -%>
 PRUNEPATHS = "<%= ((@prunepaths << @extra_prunepaths).flatten!).join(' ') %>"


### PR DESCRIPTION
Currently when run on centos 5 system 

```
<root@vb-slc5-next-01> /usr/local/bin/mlocate.cron:

updatedb:/etc/updatedb.conf:3: unknown variable `PRUNE_BIND_MOUNTS'
updatedb:/etc/updatedb.conf:5: unknown variable `PRUNENAMES'
```

mlocate is version 0.15.
