### PR TITLE
Eplicitly specify origin of class variables

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,4 +1,6 @@
-class mlocate::cron inherits mlocate {
+class mlocate::cron (
+  $cron_ensure = $::mlocate::cron_ensure
+) inherits mlocate {
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,10 @@
-class mlocate::install inherits mlocate {
+class mlocate::install (
+  $package_ensure = $::mlocate::package_ensure,
+  $package_name   = $::mlocate::package_name,
+  $conf_file      = $::mlocate::conf_file,
+  $update_command = $::mlocate::update_command,
+  $update_on_install = $::mlocate::update_on_install
+) inherits mlocate {
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")


### PR DESCRIPTION
This removes some puppet lint errors. 
