### PR TITLE
Fixed typo in dependencies in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_range": ">= 4.3.0 <5.0.0"
     }
   ]


### PR DESCRIPTION
I was receiving errors on the puppetlabs-stdlib dependency due to a typo in metadata.json.  
