### PR TITLE
Support EL7

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Ensure the cron jobs is present or absent. Default: present
 
 The standard cron time schedule. Default: once a week based on fqdn_rand
 
+####`cron_daily_path`
+
+The path to cron.daily file installed by mlocate and that is removed
+
 ####`prune_bind_mounts`
 
 Prune out bind mounts or not. Default: yes

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@
 # [*cron_schedule*]
 #   The standard cron time schedule. Default: once a week based on fqdn_rand
 #
+# [*cron_daily_path*]
+#   The path to cron.daily file installed by mlocate and that is removed.
+#
 # [*prune_bind_mounts*]
 #   Prune out bind mounts or not. Default: yes
 #   Refer to the updatedb.conf man page for more detail.
@@ -77,6 +80,7 @@ class mlocate (
 
   $cron_ensure        = $mlocate::params::cron_ensure,
   $cron_schedule      = $mlocate::params::cron_schedule,
+  $cron_daily_path    = $mlocate::params::cron_daily_path,
 
   $prune_bind_mounts  = $mlocate::params::prune_bind_mounts,
   $prunefs            = $mlocate::params::prunefs,
@@ -95,6 +99,7 @@ class mlocate (
 
   validate_re($cron_ensure, ['^present', '^absent'], "Error: \$cron_ensure must be either 'present' or 'absent'")
   validate_string($cron_schedule)
+  validate_absolute_path($cron_daily_path)
 
   if $prune_bind_mounts {
     validate_re($prune_bind_mounts, [ '^yes', '^no' ], "Error: \$prune_bind_mounts must be either 'yes', or 'no'")

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,8 @@ class mlocate::install (
   $package_name   = $::mlocate::package_name,
   $conf_file      = $::mlocate::conf_file,
   $update_command = $::mlocate::update_command,
-  $update_on_install = $::mlocate::update_on_install
+  $update_on_install = $::mlocate::update_on_install,
+  $cron_daily_path = $::mlocate::cron_daily_path,
 ) inherits mlocate {
 
   if $caller_module_name != $module_name {
@@ -35,7 +36,7 @@ class mlocate::install (
     require => File['updatedb.conf'],
   }
 
-  file { '/etc/cron.daily/mlocate.cron':
+  file { $cron_daily_path:
     ensure  => absent,
     require => Package['mlocate'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,12 @@ class mlocate::params {
     $prune_bind_mounts  = 'yes'
   }
 
+  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '7.0') >= 0 {
+    $cron_daily_path = '/etc/cron.daily/mlocate'
+  } else {
+    $cron_daily_path = '/etc/cron.daily/mlocate.cron'
+  }
+
   $prunefs = [
     '9p', 'afs', 'anon_inodefs', 'auto', 'autofs', 'bdev', 'binfmt_misc',
     'cgroup', 'cifs', 'coda', 'configfs', 'cpuset', 'debugfs', 'devpts',

--- a/metadata.json
+++ b/metadata.json
@@ -22,14 +22,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "5",
-        "6"
+        "6",
+        "7"
       ]
     }
   ],

--- a/spec/classes/mlocate_spec.rb
+++ b/spec/classes/mlocate_spec.rb
@@ -9,6 +9,8 @@ describe 'mlocate' do
           facts
         end
 
+        it { should compile.with_all_deps }
+
         context 'with defaults for all parameters' do
           it { should contain_class('mlocate') }
           it { should contain_class('mlocate::install') }


### PR DESCRIPTION
Add cron_daily_path parameter that sets path of cron.daily file installed by mlocate and removed by this module - default is unchanged from previous value except on RedHat >= 7
