### PR TITLE
Add parameter update_command_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ The name of the package to install. Default: mlocate
 
 Ensure the package is present, latest, or absent. Default: present
 
+####`update_command_path`
+
+The path of the updatedb wrapper script. Default: $update_command
+
 ####`update_command`
 
 The name of the updatedb wrapper script. Default: /usr/local/bin/mlocate.cron

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,9 @@
 # [*package_ensure*]
 #   Ensure the package is present, latest, or absent. Default: present
 #
+# [*update_command_path*]
+#   The path to the updatedb wrapper script.  Default: $update_command
+#
 # [*update_command*]
 #   The name of the updatedb wrapper script. Default: /usr/local/bin/mlocate.cron
 #
@@ -77,6 +80,7 @@
 class mlocate (
   $package_name          = $mlocate::params::package_name,
   $package_ensure        = $mlocate::params::package_ensure,
+  $update_command_path   = $mlocate::params::update_command_path,
   $update_command        = $mlocate::params::update_command,
   $deploy_update_command = $mlocate::params::deploy_update_command,
   $update_on_install     = $mlocate::params::update_on_install,
@@ -97,6 +101,8 @@ class mlocate (
 
   validate_string($package_name)
   validate_re($package_ensure, ['^present', '^latest', '^absent'], "Error: \$package_ensure must be either 'present', 'latest', or 'absent'")
+  $_update_command_path = pick($update_command_path, $update_command)
+  validate_absolute_path($_update_command_path)
   validate_absolute_path($update_command)
   validate_bool($deploy_update_command)
   validate_bool($update_on_install)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,6 +2,7 @@ class mlocate::install (
   $package_ensure        = $::mlocate::package_ensure,
   $package_name          = $::mlocate::package_name,
   $conf_file             = $::mlocate::conf_file,
+  $update_command_path   = $::mlocate::_update_command_path,
   $update_command        = $::mlocate::update_command,
   $deploy_update_command = $::mlocate::deploy_update_command,
   $update_on_install     = $::mlocate::update_on_install,
@@ -30,7 +31,7 @@ class mlocate::install (
   if $deploy_update_command {
     file { 'update_command':
       ensure  => file,
-      path    => $update_command,
+      path    => $update_command_path,
       owner   => 'root',
       group   => 'root',
       mode    => '0555',
@@ -48,7 +49,7 @@ class mlocate::install (
   }
 
   if $update_on_install == true {
-    exec { $update_command:
+    exec { $update_command_path:
       refreshonly => true,
       creates     => '/var/lib/mlocate/mlocate.db',
       subscribe   => Package['mlocate'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class mlocate::params {
 
   $package_name          = 'mlocate'
   $package_ensure        = 'present'
+  $update_command_path    = undef
   $update_command        = '/usr/local/bin/mlocate.cron'
   $deploy_update_command = true
   $update_on_install     = true


### PR DESCRIPTION
  Add update_command_path parameter that defaults value is the value of $update_command
  Allows a custom update command to be used that is more than just the path to wrapper script
