### PR TITLE
Bug, don't require update_command script if not deployed

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -37,6 +37,9 @@ class mlocate::install (
       source  => "puppet:///modules/${module_name}/mlocate.cron",
       require => File['updatedb.conf'],
     }
+    $_exec_require = File['update_command']
+  } else {
+    $_exec_require = undef
   }
 
   file { $cron_daily_path:
@@ -49,7 +52,7 @@ class mlocate::install (
       refreshonly => true,
       creates     => '/var/lib/mlocate/mlocate.db',
       subscribe   => Package['mlocate'],
-      require     => File['update_command'],
+      require     => $_exec_require,
     }
   }
 }

--- a/spec/classes/mlocate_spec.rb
+++ b/spec/classes/mlocate_spec.rb
@@ -20,6 +20,7 @@ describe 'mlocate' do
           it { should contain_file('updatedb.conf').with_content(/^PRUNEFS = \"9p afs .*$/) }
 
           it { should contain_file('update_command').with_path('/usr/local/bin/mlocate.cron') }
+          it { should contain_exec('/usr/local/bin/mlocate.cron') }
 
           if facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease] == '5'
             it { should contain_file('updatedb.conf').without_content(/^PRUNE_BIND_MOUNTS.*$/) }
@@ -37,6 +38,7 @@ describe 'mlocate' do
             }
           end
           it { should contain_file('update_command').with_path('/tmp/junk') }
+          it { should contain_exec('/tmp/junk') }
         end
         context 'with update_command set and deploy_update_command false' do
           let(:params) do
@@ -44,6 +46,23 @@ describe 'mlocate' do
               deploy_update_command: false }
           end
           it { should_not contain_file('update_command') }
+          it { should contain_exec('/tmp/junk') }
+        end
+        context 'with update_command set and update_on_install false' do
+          let(:params) do
+            { update_command: '/tmp/junk',
+              update_on_install: false }
+          end
+	  it { should contain_file('update_command').with_path('/tmp/junk') }
+          it { should_not contain_exec('/tmp/junk') }
+        end
+        context 'with update_command set and update_on_install true' do
+          let(:params) do
+            { update_command: '/tmp/junk',
+              update_on_install: true }
+          end
+	  it { should contain_file('update_command').with_path('/tmp/junk') }
+          it { should contain_exec('/tmp/junk') }
         end
       end
     end

--- a/spec/classes/mlocate_spec.rb
+++ b/spec/classes/mlocate_spec.rb
@@ -29,21 +29,21 @@ describe 'mlocate' do
             it { should contain_file('updatedb.conf').with_content(/^PRUNENAMES = ".git .hg .svn"$/) }
           end
         end
-        context 'with some parameters set and booleans true' do
+        context 'with update_command set and deploy_update_command true' do
           let(:params) do
             {
               update_command: '/tmp/junk',
               deploy_update_command: true
             }
-            it { should contain_file('update_command').with_path('/tmp/jumk') }
           end
+          it { should contain_file('update_command').with_path('/tmp/junk') }
         end
-        context 'with some parameters set and booleans false' do
+        context 'with update_command set and deploy_update_command false' do
           let(:params) do
             { update_command: '/tmp/junk',
               deploy_update_command: false }
-            it { should_not contain_file('update_command') }
           end
+          it { should_not contain_file('update_command') }
         end
       end
     end


### PR DESCRIPTION
When `deploy_update_script` was false the file was
was still required by the exec of that script.

In addition the rspec tests for this were not actually
being executed.